### PR TITLE
Update the resources and variables to use 'eirini' instead of 'cube'

### DIFF
--- a/env/eirini-ci.yml
+++ b/env/eirini-ci.yml
@@ -6,4 +6,4 @@ bosh_lite_name: eirini-ci
 cc_api: https://api.eirini.dynamic-dns.net
 cf-deployment-version: v1.20.0
 registry_address: registry.eirini.dynamic-dns.net:8089
-eirini-release-branch: develop
+eirini-release-branch: master

--- a/stubs/eirini-dev.yml
+++ b/stubs/eirini-dev.yml
@@ -61,13 +61,13 @@ resources:
 - name: ci-resources
   type: git
   source:
-    uri: https://github.com/cloudfoundry-incubator/eirini-ci.git
+    uri: https://code.cloudfoundry.org/eirini-ci.git
     branch: master
 
 - name: eirini-release
   type: git
   source:
-    uri: https://github.com/cloudfoundry-incubator/eirini-release.git
+    uri: https://code.cloudfoundry.org/eirini-release.git
     branch: ((eirini-release-branch))
 
 - name: cf-deployment

--- a/stubs/eirini-dev.yml
+++ b/stubs/eirini-dev.yml
@@ -67,7 +67,7 @@ resources:
 - name: eirini-release
   type: git
   source:
-    uri: https://github.com/andrew-edgar/cube-release.git
+    uri: https://github.com/cloudfoundry-incubator/eirini-release.git
     branch: ((eirini-release-branch))
 
 - name: cf-deployment

--- a/stubs/eirini-dev.yml
+++ b/stubs/eirini-dev.yml
@@ -61,13 +61,13 @@ resources:
 - name: ci-resources
   type: git
   source:
-    uri: https://code.cloudfoundry.org/eirini-ci.git
+    uri: https://github.com/cloudfoundry-incubator/eirini-ci.git
     branch: master
 
 - name: eirini-release
   type: git
   source:
-    uri: https://code.cloudfoundry.org/eirini-release.git
+    uri: https://github.com/cloudfoundry-incubator/eirini-release.git
     branch: ((eirini-release-branch))
 
 - name: cf-deployment

--- a/stubs/include-unit-tests.yml
+++ b/stubs/include-unit-tests.yml
@@ -18,5 +18,5 @@ resources:
 - name: eirini
   type: git
   source:
-    uri: https://github.com/julz/cube.git
+    uri: https://github.com/cloudfoundry-incubator/eirini.git
     branch: master

--- a/stubs/include-unit-tests.yml
+++ b/stubs/include-unit-tests.yml
@@ -18,5 +18,5 @@ resources:
 - name: eirini
   type: git
   source:
-    uri: https://github.com/cloudfoundry-incubator/eirini.git
+    uri: https://code.cloudfoundry.org/eirini.git
     branch: master

--- a/tasks/create-manifest.sh
+++ b/tasks/create-manifest.sh
@@ -21,7 +21,7 @@ bosh int ../cf-deployment/cf-deployment.yml \
      -o ../cf-deployment/operations/use-compiled-releases.yml \
      -o ../cf-deployment/operations/bosh-lite.yml \
      -o ../cf-deployment/operations/experimental/use-bosh-dns.yml \
-     -o ./operations/cube-bosh-operations.yml \
+     -o ./operations/eirini-bosh-operations.yml \
      -o ./operations/dev-version.yml \
      -o ../cf-deployment/iaas-support/softlayer/add-system-domain-dns-alias.yml \
      --var=k8s_flatten_cluster_config="$(kubectl config view --flatten=true)" \
@@ -32,7 +32,7 @@ bosh int ../cf-deployment/cf-deployment.yml \
      -v nats_ip=$NATS_IP \
      -v nats_password=$nats_password \
      -v registry_address=$REGISTRY_ADDRESS \
-     -v cube_ip=$EIRINI_IP \
-     -v cube_address=$EIRINI_ADDRESS \
-     -v cube_local_path=./ > ../manifest/manifest.yml
+     -v eirini_ip=$EIRINI_IP \
+     -v eirini_address=$EIRINI_ADDRESS \
+     -v eirini_local_path=./ > ../manifest/manifest.yml
 

--- a/tasks/deploy-eirini-release.sh
+++ b/tasks/deploy-eirini-release.sh
@@ -14,7 +14,7 @@ pushd ./eirini-release
 
 bosh sync-blobs
 
-bosh add-blob /eirini/eirinifs.tar cubefs/cubefs.tar
+bosh add-blob /eirini/eirinifs.tar eirinifs/eirinifs.tar
 
 git submodule update --init --recursive
 

--- a/tasks/run-unit-tests.sh
+++ b/tasks/run-unit-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 readonly BASEDIR="$(cd $(dirname $0)/.. && pwd)"
-readonly DEFAULTS="launcher blobondemand vendor scripts cmd opi cubefakes"
+readonly DEFAULTS="launcher blobondemand vendor scripts cmd opi eirinifakes"
 readonly EXCLUDE="$DEFAULTS $@"
-readonly WORKSPACE="$GOPATH/src/github.com/julz/cube"
+readonly WORKSPACE="$GOPATH/src/github.com/cloudfoundry-incubator/eirini"
 
 setupTestEnv(){
 	mkdir -p $WORKSPACE

--- a/tasks/run-unit-tests.sh
+++ b/tasks/run-unit-tests.sh
@@ -3,7 +3,7 @@
 readonly BASEDIR="$(cd $(dirname $0)/.. && pwd)"
 readonly DEFAULTS="launcher blobondemand vendor scripts cmd opi eirinifakes"
 readonly EXCLUDE="$DEFAULTS $@"
-readonly WORKSPACE="$GOPATH/src/github.com/cloudfoundry-incubator/eirini"
+readonly WORKSPACE="$GOPATH/src/code.cloudfoundry.org/eirini"
 
 setupTestEnv(){
 	mkdir -p $WORKSPACE


### PR DESCRIPTION
Update the `eirini` and `eirini-release` resources to point to the new repos
contained in `cloudfoundry-incubator` organization.

Update other relevant variables and parameters.

[#157657086]