### PR TITLE
Rebase cloud_controller_ng fork correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ custom.yml
 /pipeline.yml
 /pipelines/docker-images/spruced.yml
 /pipelines/deploy-script/spruced.yml
+/pipelines/rebase/spruced.yml

--- a/pipelines/rebase/aviator.yml
+++ b/pipelines/rebase/aviator.yml
@@ -1,0 +1,9 @@
+spruce:
+- base: $SCRIPT_DIR/pipeline.yml
+  merge:
+  - with:
+      files:
+      - $REPO_ROOT/stubs/notify/resource.yml
+      - $REPO_ROOT/stubs/notify/rebase-cc.yml
+  to: $SCRIPT_DIR/spruced.yml
+

--- a/pipelines/rebase/pipeline.yml
+++ b/pipelines/rebase/pipeline.yml
@@ -1,14 +1,16 @@
 jobs:
-- name: rebase-capi
+- name: Keep-CC-up-to-date
   plan:
   - get: ci-resources
+  - get: cc-ng-fork
   - get: cc-ng
     trigger: true
-  - get: cc-ng-fork
+  - task: rebase
+    file: ci-resources/tasks/rebase-cc.yml
   - put: cc-ng-fork
     params:
-      repository: cc-ng
-      rebase: true
+      repository: rebased-cc
+      force: true
 
 resources:
 - name: cc-ng-fork
@@ -17,15 +19,13 @@ resources:
     uri: git@github.com:mnitchev/cloud_controller_ng.git
     branch: eirini
     private_key: ((cc_ng_key))
-
 - name: cc-ng
   type: git
   source:
     uri: http://github.com/cloudfoundry/cloud_controller_ng.git
     branch: master
-
 - name: ci-resources
   type: git
   source:
     uri: https://github.com/cloudfoundry-incubator/eirini-ci.git
-    branch: master
+    branch: cc-rebase

--- a/pipelines/rebase/set-pipeline
+++ b/pipelines/rebase/set-pipeline
@@ -1,8 +1,24 @@
 #!/bin/bash
 
-readonly TARGET="${1?target not defined}"
+if [ "$1" == "help" ]; then
+    cat << EOF
+  Usage:
+
+        $ ./set-pipeline <CONCOURSE_TARGET> <PRIVATE_REPO>
+EOF
+    exit 0
+fi
+
+export TARGET="${1?target not defined}"
+export PRIVATE_REPO="${2?private repo not defined}"
+
+export SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export REPO_ROOT="$(cd "$SCRIPT_DIR"/../.. && pwd)"
+
+aviator -f "$SCRIPT_DIR"/aviator.yml
 
 fly -t "$TARGET" set-pipeline \
-  --config rebase-capi.yml \
-	--pipeline rebase-cc \
-	--var cc_ng_key="$(pass eirini/github/mnitchev/cloud_controller_ng/ssh-key)"
+    --config "$SCRIPT_DIR"/spruced.yml \
+    --pipeline rebase-cc \
+    --load-vars-from "$PRIVATE_REPO/concourse/common.yml" \
+    --var cc_ng_key="$(pass eirini/github/mnitchev/cloud_controller_ng/ssh-key)"

--- a/stubs/notify/rebase-cc.yml
+++ b/stubs/notify/rebase-cc.yml
@@ -1,0 +1,4 @@
+jobs:
+- ((merge))
+- name: Keep-CC-up-to-date
+  .: (( inject hooks.failure ))

--- a/tasks/rebase-cc.sh
+++ b/tasks/rebase-cc.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -ex
+
+main() {
+    rebase
+    restore-commiters
+    copy-resource
+}
+
+rebase() {
+    pushd cc-ng-fork
+        git checkout "$FORK_BRANCH"
+        git remote add upstream "$UPSTREAM"
+
+        git pull upstream $UPSTREAM_BRANCH --rebase
+    popd
+}
+
+# This is necessary because git does not let you keep the committers after rebase
+# This function restores them by parsing the 'Signed-off-by' message footer, if available
+restore-commiters() {
+    pushd cc-ng-fork
+        diff=$(git rev-list --right-only --count upstream/$UPSTREAM_BRANCH..$FORK_BRANCH)
+        start_commit=HEAD~"$diff"
+        end_commit=HEAD
+
+        git filter-branch --commit-filter '
+            #!/bin/bash
+            COMMIT_MESSAGE=$(git log --format=%B -n 1 $GIT_COMMIT);
+            SIGNED_OFF=$(echo "$COMMIT_MESSAGE" | grep "Signed-off-by: " | sed "s/^.*: //" | head -n 1);
+            if [ -z "$SIGNED_OFF" ]; then git commit-tree "$@" && return 0; fi
+            FIRSTNAME=$(echo "$SIGNED_OFF" | cut -d " " -f 1);
+            LASTNAME=$(echo "$SIGNED_OFF" | cut -d " " -f 2);
+            export GIT_COMMITTER_NAME="${FIRSTNAME} ${LASTNAME}";
+            export GIT_COMMITTER_EMAIL=$(echo "$SIGNED_OFF" | cut -d " " -f 3 | sed -e "s/^.//" -e "s/.$//")
+            git commit-tree "$@";
+            ' "$start_commit".."$end_commit"
+    popd
+
+}
+
+copy-resource() {
+    cp -r cc-ng-fork/. rebased-cc/
+}
+
+main
+

--- a/tasks/rebase-cc.yml
+++ b/tasks/rebase-cc.yml
@@ -1,0 +1,23 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: eirini/ci
+
+params:
+  FORK_BRANCH: eirini
+  UPSTREAM: ../cc-ng
+  UPSTREAM_BRANCH: master
+
+inputs:
+- name: ci-resources
+- name: cc-ng-fork
+- name: cc-ng
+
+outputs:
+- name: rebased-cc
+
+run:
+  path: ci-resources/tasks/rebase-cc.sh


### PR DESCRIPTION
Rebase our commits on top of upstream master instead of the other way around.

[#159883481]